### PR TITLE
DX: (PHP => Composer) simplify rule "section is correct"

### DIFF
--- a/rules/php/composer/rule/section_is_correct.go
+++ b/rules/php/composer/rule/section_is_correct.go
@@ -25,8 +25,8 @@ type sectionValue[T comparable] struct {
 
 func NewSectionHasCorrectValueRule[T comparable](
 	section string,
-	expectedValue []T,
 	actualValue T,
+	expectedValue ...T,
 ) *SectionHasCorrectValueRule[T] {
 	return &SectionHasCorrectValueRule[T]{
 		value: sectionValue[T]{

--- a/rules/php/composer/rule/section_is_correct_test.go
+++ b/rules/php/composer/rule/section_is_correct_test.go
@@ -11,7 +11,7 @@ import (
 func TestSectionIsCorrect(t *testing.T) {
 	t.Run("success cases", func(t *testing.T) {
 		t.Run("#1 the single expected value equals actual", func(t *testing.T) {
-			r := rule.NewSectionHasCorrectValueRule("type", []string{"project"}, "project")
+			r := rule.NewSectionHasCorrectValueRule("type", "project", "project")
 			r.Validate()
 
 			assert.True(t, r.IsPassed())
@@ -20,10 +20,9 @@ func TestSectionIsCorrect(t *testing.T) {
 		t.Run("#2 one of expected values equals actual", func(t *testing.T) {
 			r := rule.NewSectionHasCorrectValueRule(
 				"type",
-				[]string{
-					"library",
-					"symfony-bundle",
-				},
+				"symfony-bundle",
+
+				"library",
 				"symfony-bundle",
 			)
 			r.Validate()
@@ -34,21 +33,28 @@ func TestSectionIsCorrect(t *testing.T) {
 
 	t.Run("failure cases", func(t *testing.T) {
 		t.Run("#1 single expected value != actual", func(t *testing.T) {
-			r := rule.NewSectionHasCorrectValueRule("type", []string{"project"}, "library")
+			r := rule.NewSectionHasCorrectValueRule("type", "library", "project")
 			r.Validate()
 
 			assert.False(t, r.IsPassed())
 		})
 
 		t.Run("#2 actual value != any of expected", func(t *testing.T) {
-			r := rule.NewSectionHasCorrectValueRule("type", []string{"project", "symfony-bundle", "value"}, "library")
+			r := rule.NewSectionHasCorrectValueRule(
+				"type",
+				"library",
+
+				"project",
+				"symfony-bundle",
+				"value",
+			)
 			r.Validate()
 
 			assert.False(t, r.IsPassed())
 		})
 
 		t.Run("#3 expected value does not set", func(t *testing.T) {
-			r := rule.NewSectionHasCorrectValueRule("type", []string{}, "library")
+			r := rule.NewSectionHasCorrectValueRule("type", "library")
 			r.Validate()
 
 			assert.False(t, r.IsPassed())


### PR DESCRIPTION
PR https://github.com/dozer111/projectlinter-core/pull/16 add new ability to check multiple section values at once. But, as a developer - I am not satisfied of this realization. It is too hard to write some simple things:

```go
typeIsCorrect := rule.NewSectionHasCorrectValueRule(
    "type", 
    []string{"project"}, 
    actualTypeValue
)

configSortPackagesIsCorrect := rule.NewSectionHasCorrectValueRule(
			"config:sort-packages",
			[]bool{expectedSortPackages},
			actualSortPackages,
)
```

its annoying.

The better solution - swap actual and expected values and set multivalues only when I really need it:

```go
typeIsCorrect := rule.NewSectionHasCorrectValueRule(
    "type",
    actualTypeValue
    
    "project",
    "symfony-bundle"
)

configSortPackagesIsCorrect := rule.NewSectionHasCorrectValueRule(
    "config:sort-packages",
    actualSortPackages,
    expectedSortPackages,
)
```