### PR TITLE
(php composer) add new field "config.bump-after-update"

### DIFF
--- a/rules/php/composer/config/composer_json/raw_composer_json.go
+++ b/rules/php/composer/config/composer_json/raw_composer_json.go
@@ -23,9 +23,10 @@ type RawComposerJson struct {
 }
 
 type RawComposerJsonConfigSection struct {
-	SortPackages *bool              `json:"sort-packages,omitempty"`
-	Platform     *map[string]string `json:"platform,omitempty"`
-	AllowPlugins *map[string]bool   `json:"allow-plugins,omitempty"`
+	SortPackages    *bool              `json:"sort-packages,omitempty"`
+	BumpAfterUpdate *string            `json:"bump-after-update,omitempty"`
+	Platform        *map[string]string `json:"platform,omitempty"`
+	AllowPlugins    *map[string]bool   `json:"allow-plugins,omitempty"`
 }
 
 type RawComposerJsonAutoloadSection struct {

--- a/rules/php/composer/parser/parser_test.go
+++ b/rules/php/composer/parser/parser_test.go
@@ -2,12 +2,14 @@ package parser_test
 
 import (
 	"errors"
+	"testing"
+
+	utilTest "github.com/dozer111/projectlinter-core/util/test"
+	"github.com/google/go-cmp/cmp"
+
 	"github.com/dozer111/projectlinter-core/rules/php/composer/config/composer_json"
 	"github.com/dozer111/projectlinter-core/rules/php/composer/config/composer_lock"
 	"github.com/dozer111/projectlinter-core/rules/php/composer/parser"
-	utilTest "github.com/dozer111/projectlinter-core/util/test"
-	"github.com/google/go-cmp/cmp"
-	"testing"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -15,9 +17,9 @@ import (
 func TestParseSuccess(t *testing.T) {
 	expectedComposerJson := &composer_json.RawComposerJson{
 		"private-git/some-project",
-		utilTest.ToPointer("project"),
-		utilTest.ToPointer("some php project"),
-		utilTest.ToPointer("proprietary"),
+		pointer("project"),
+		pointer("some php project"),
+		pointer("proprietary"),
 		nil,
 		nil,
 		map[string]string{
@@ -45,11 +47,10 @@ func TestParseSuccess(t *testing.T) {
 			},
 		},
 		&composer_json.RawComposerJsonConfigSection{
-			utilTest.ToPointer(true),
-			utilTest.ToPointer(map[string]string{
-				"php": "8.2",
-			}),
-			utilTest.ToPointer(map[string]bool{
+			pointer(true),
+			pointer("dev"),
+			pointer(map[string]string{"php": "8.2"}),
+			pointer(map[string]bool{
 				"symfony/flex":       true,
 				"php-http/discovery": true,
 			}),
@@ -144,4 +145,8 @@ func TestParserReturnErrorWhileComposerLockIsAbsent(t *testing.T) {
 	assert.Nil(t, actualComposerLock)
 	assert.Error(t, err)
 	assert.True(t, errors.Is(err, parser.ComposerLockNotFound))
+}
+
+func pointer[T any](val T) *T {
+	return &val
 }

--- a/rules/php/composer/parser/testdata/success/composer.json
+++ b/rules/php/composer/parser/testdata/success/composer.json
@@ -38,7 +38,8 @@
         "platform": {
             "php": "8.2"
         },
-        "sort-packages": true
+        "sort-packages": true,
+        "bump-after-update": "dev"
     },
     "extra": {
         "symfony": {


### PR DESCRIPTION
composer 2.8 bring us new cool configuration: "bump-after-config": https://getcomposer.org/doc/06-config.md#bump-after-update

projectlinter now can parse it