### PR TITLE
(php composer) improve bump-after-update

### DIFF
--- a/rules/php/composer/config/composer_json/raw_composer_json.go
+++ b/rules/php/composer/config/composer_json/raw_composer_json.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+
+	composerCustomType "github.com/dozer111/projectlinter-core/rules/php/composer/config/composer_json/type"
 )
 
 type RawComposerJson struct {
@@ -23,10 +25,10 @@ type RawComposerJson struct {
 }
 
 type RawComposerJsonConfigSection struct {
-	SortPackages    *bool              `json:"sort-packages,omitempty"`
-	BumpAfterUpdate *string            `json:"bump-after-update,omitempty"`
-	Platform        *map[string]string `json:"platform,omitempty"`
-	AllowPlugins    *map[string]bool   `json:"allow-plugins,omitempty"`
+	SortPackages    *bool                          `json:"sort-packages,omitempty"`
+	BumpAfterUpdate *composerCustomType.BoolString `json:"bump-after-update,omitempty"`
+	Platform        *map[string]string             `json:"platform,omitempty"`
+	AllowPlugins    *map[string]bool               `json:"allow-plugins,omitempty"`
 }
 
 type RawComposerJsonAutoloadSection struct {

--- a/rules/php/composer/config/composer_json/type/bool_string.go
+++ b/rules/php/composer/config/composer_json/type/bool_string.go
@@ -1,0 +1,33 @@
+package composerCustomType
+
+import (
+	"encoding/json"
+	"errors"
+)
+
+// BoolString can hold either a string or a bool.
+type BoolString struct {
+	IsBool  bool
+	BoolVal bool
+	StrVal  string
+}
+
+var _ json.Unmarshaler = (*BoolString)(nil)
+
+func (sb *BoolString) UnmarshalJSON(data []byte) error {
+	var boolVal bool
+	if err := json.Unmarshal(data, &boolVal); err == nil {
+		sb.IsBool = true
+		sb.BoolVal = boolVal
+		return nil
+	}
+
+	var stringVal string
+	if err := json.Unmarshal(data, &stringVal); err == nil {
+		sb.IsBool = false
+		sb.StrVal = stringVal
+		return nil
+	}
+
+	return errors.New("value is neither bool nor string")
+}

--- a/rules/php/composer/config/composer_json/type/bool_string_test.go
+++ b/rules/php/composer/config/composer_json/type/bool_string_test.go
@@ -1,0 +1,30 @@
+package composerCustomType_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	composerCustomType "github.com/dozer111/projectlinter-core/rules/php/composer/config/composer_json/type"
+)
+
+func TestBoolString(t *testing.T) {
+	t.Run("string", func(t *testing.T) {
+		var actualObj composerCustomType.BoolString
+		err := json.Unmarshal([]byte(`"dondo"`), &actualObj)
+
+		assert.NoError(t, err)
+		assert.False(t, actualObj.IsBool)
+		assert.Equal(t, actualObj.StrVal, "dondo")
+	})
+
+	t.Run("bool", func(t *testing.T) {
+		var actualObj composerCustomType.BoolString
+		err := json.Unmarshal([]byte(`false`), &actualObj)
+
+		assert.NoError(t, err)
+		assert.True(t, actualObj.IsBool)
+		assert.Equal(t, actualObj.BoolVal, false)
+	})
+}

--- a/rules/php/composer/config/composer_json/type/doc.go
+++ b/rules/php/composer/config/composer_json/type/doc.go
@@ -1,0 +1,15 @@
+package composerCustomType
+
+// package composerCustomType
+//
+// contains some types, that can be faced in real composer values
+//
+// example: https://getcomposer.org/doc/06-config.md#bump-after-update
+// - "bump-after-update": "dev"
+// - "bump-after-update": true
+//
+// This value can be either bool or string
+//
+// So, we need more instruments to handle such cases
+//
+//

--- a/rules/php/composer/parser/parser_test.go
+++ b/rules/php/composer/parser/parser_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 
 	"github.com/dozer111/projectlinter-core/rules/php/composer/config/composer_json"
+	composerCustomType "github.com/dozer111/projectlinter-core/rules/php/composer/config/composer_json/type"
 	"github.com/dozer111/projectlinter-core/rules/php/composer/config/composer_lock"
 	"github.com/dozer111/projectlinter-core/rules/php/composer/parser"
 
@@ -48,7 +49,7 @@ func TestParseSuccess(t *testing.T) {
 		},
 		&composer_json.RawComposerJsonConfigSection{
 			pointer(true),
-			pointer("dev"),
+			&composerCustomType.BoolString{StrVal: "dev"},
 			pointer(map[string]string{"php": "8.2"}),
 			pointer(map[string]bool{
 				"symfony/flex":       true,


### PR DESCRIPTION
On the first time, the implementation of "bump-after-update" field was a string.

But, actually, it can also be a bool: https://getcomposer.org/doc/06-config.md#bump-after-update

And I know, that this config is a not unique case. Composer configuration has some other fields with dual nature. 

So I add this dual field to improve the way you can control it