### PR TITLE
:warning:  (php|composer ) Improve `dependencies constraints are valid` rule

### DIFF
--- a/rules/php/composer/rule/dependencies_constraint_are_valid.go
+++ b/rules/php/composer/rule/dependencies_constraint_are_valid.go
@@ -2,37 +2,33 @@ package rule
 
 import (
 	"fmt"
+
 	"github.com/dozer111/projectlinter-core/rules"
+
 	"github.com/dozer111/projectlinter-core/rules/php/composer/config/composer_json"
-	utilSet "github.com/dozer111/projectlinter-core/util/set"
-	"regexp"
 )
 
-// DependenciesConstrainsAreValidRule
-// TODO add some output that when we have a library in exception and it is the correct version - show the user that this library can be removed from exceptions
 type DependenciesConstrainsAreValidRule struct {
-	dependencies *composer_json.ComposerDependencies
-	// exceptions list of libraries that brake this rule
-	// The idea is that some dependencies are known to never have a "correct" dependency
-	// For example: "ext-json": "*",
-	//
-	// Therefore, we deliberately exclude them
-	exceptions *utilSet.Set[string]
+	dependencies   *composer_json.ComposerDependencies
+	validationFunc func(string) bool
 
-	depsWithWrongConstraint *composer_json.ComposerDependencies
-	isPassed                bool
+	depsWithWrongConstraint     *composer_json.ComposerDependencies
+	additionalFailedMessageText []string
+	isPassed                    bool
 }
 
 var _ rules.Rule = (*DependenciesConstrainsAreValidRule)(nil)
 
 func NewDependenciesConstrainsAreValidRule(
 	deps *composer_json.ComposerDependencies,
-	exceptions []string,
+	validationFunc func(string) bool,
+	additionalFailedMessageText []string,
 ) *DependenciesConstrainsAreValidRule {
 	return &DependenciesConstrainsAreValidRule{
-		dependencies:            deps,
-		exceptions:              utilSet.NewSet[string](exceptions...),
-		depsWithWrongConstraint: composer_json.NewComposerDependencies(),
+		dependencies:                deps,
+		validationFunc:              validationFunc,
+		additionalFailedMessageText: additionalFailedMessageText,
+		depsWithWrongConstraint:     composer_json.NewComposerDependencies(),
 	}
 }
 
@@ -45,22 +41,10 @@ func (r *DependenciesConstrainsAreValidRule) Title() string {
 }
 
 func (r *DependenciesConstrainsAreValidRule) Validate() {
-	r1 := regexp.MustCompile(`^\^\d+$`)           // ^3
-	r2 := regexp.MustCompile(`^\^\d+\.\d+$`)      // ^3.2
-	r3 := regexp.MustCompile(`^\^\d+\.\d+\.\d+$`) // ^3.2.15
-
 	for _, d := range r.dependencies.All() {
-		if r1.MatchString(d.Constraint()) ||
-			r2.MatchString(d.Constraint()) ||
-			r3.MatchString(d.Constraint()) {
-			continue
+		if !r.validationFunc(d.Constraint()) {
+			r.depsWithWrongConstraint.Add(d)
 		}
-
-		if r.exceptions.Has(d.Name()) {
-			continue
-		}
-
-		r.depsWithWrongConstraint.Add(d)
 	}
 
 	r.isPassed = r.depsWithWrongConstraint.Count() == 0
@@ -71,17 +55,23 @@ func (r *DependenciesConstrainsAreValidRule) IsPassed() bool {
 }
 
 func (r *DependenciesConstrainsAreValidRule) FailedMessage() []string {
-	result := []string{
-		`Dependency constraint(except "ext-") must match one of patterns: ^d+.d+(^8.1) or ^d+.d+.d+(^8.1.2)`,
-		"- ^d+$         ^8",
-		"- ^d+.d+$      ^8.1",
-		"- ^d+.d+.d+$   ^8.1.2",
-		"",
-		`These libraries does not match it:`,
-	}
+	result := r.additionalFailedMessageText
 
-	for _, r := range r.depsWithWrongConstraint.All() {
-		result = append(result, fmt.Sprintf("	\"%s\": \"%s\"", r.Name(), r.Constraint()))
+	result = append(
+		result,
+		"",
+		"This library dependenies is wrong:",
+	)
+
+	for _, depWithWrongConstraint := range r.depsWithWrongConstraint.All() {
+		result = append(
+			result,
+			fmt.Sprintf(
+				"	\"%s\": \"%s\"",
+				depWithWrongConstraint.Name(),
+				depWithWrongConstraint.Constraint(),
+			),
+		)
 	}
 
 	return result

--- a/rules/php/composer/rule/dependencies_constraint_are_valid.go
+++ b/rules/php/composer/rule/dependencies_constraint_are_valid.go
@@ -60,7 +60,7 @@ func (r *DependenciesConstrainsAreValidRule) FailedMessage() []string {
 	result = append(
 		result,
 		"",
-		"This library dependenies is wrong:",
+		"This library dependencies is wrong:",
 	)
 
 	for _, depWithWrongConstraint := range r.depsWithWrongConstraint.All() {


### PR DESCRIPTION
Change the rule "Dependencies constraints are valid"

---

Before: this rule was not flexible. It has its own pattern, and all you can do with it - add your dependencies to ignore or dont use the rule

This is not correct. In my mind this rule MUST BE flexible.

---

Real world example:

in service i expect that all the dependencies would have semver constraint starting with `^`(e.g "^8","^8.1","^8.1.1"), because it absolutely clear and strict

in libraries on the same time, it is valid situation to have a constraints like "^5 || ^6 || ^7"

---

So, updated rule give you this flexibility. Now only the person who use the rule can say - either the constraint is valid or not

---

This change would be in release 1.1

I understand that i break backward compatibility. Now project is not so popular, so I can accept myself such things
